### PR TITLE
Implement a limited version of Pattern

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,48 @@ extern crate alloc;
 use alloc::string::String;
 use core::intrinsics::copy;
 
+mod sealed {
+    pub enum ConcretePattern<'a> {
+        Func(&'a mut dyn FnMut(char) -> bool),
+        Str(&'a str),
+        Char(char),
+    }
+
+    pub trait Pattern {
+        fn as_pattern_enum(&mut self) -> ConcretePattern<'_>;
+    }
+
+    impl Pattern for char {
+        fn as_pattern_enum(&mut self) -> ConcretePattern<'_> {
+            ConcretePattern::Char(*self)
+        }
+    }
+
+    impl Pattern for str {
+        fn as_pattern_enum(&mut self) -> ConcretePattern<'_> {
+            ConcretePattern::Str(self)
+        }
+    }
+
+    impl<F: FnMut(char) -> bool> Pattern for F {
+        fn as_pattern_enum(&mut self) -> ConcretePattern<'_> {
+            ConcretePattern::Func(self)
+        }
+    }
+}
+
+use sealed::Pattern;
+
+macro_rules! deconstruct_pattern {
+    ($func:path, $self:ident, $arg:ident) => {
+        match sealed::Pattern::as_pattern_enum(&mut $arg) {
+            sealed::ConcretePattern::Func(val) => $func($self, val),
+            sealed::ConcretePattern::Char(val) => $func($self, val),
+            sealed::ConcretePattern::Str(val) => $func($self, val),
+        }
+    };
+}
+
 pub trait TrimInPlace {
     fn trim_in_place(&mut self) -> &str;
     fn trim_start_in_place(&mut self) -> &str;
@@ -36,8 +78,8 @@ pub trait TrimInPlace {
 
     // TODO trim_matches with Pattern
     fn trim_matches_in_place(&mut self, pat: char) -> &str;
-    fn trim_start_matches_in_place(&mut self, pat: char) -> &str;
-    fn trim_end_matches_in_place(&mut self, pat: char) -> &str;
+    fn trim_start_matches_in_place(&mut self, pat: impl Pattern) -> &str;
+    fn trim_end_matches_in_place(&mut self, pat: impl Pattern) -> &str;
 }
 
 impl TrimInPlace for String {
@@ -107,8 +149,8 @@ impl TrimInPlace for String {
     }
 
     #[inline]
-    fn trim_start_matches_in_place(&mut self, pat: char) -> &str {
-        let trimmed_str = self.trim_start_matches(pat);
+    fn trim_start_matches_in_place(&mut self, mut pat: impl Pattern) -> &str {
+        let trimmed_str = deconstruct_pattern!(str::trim_start_matches, self, pat);
 
         let trimmed_str_start_pointer = trimmed_str.as_ptr();
         let trimmed_str_length = trimmed_str.len();
@@ -125,8 +167,8 @@ impl TrimInPlace for String {
     }
 
     #[inline]
-    fn trim_end_matches_in_place(&mut self, pat: char) -> &str {
-        let trimmed_str_length = self.trim_end_matches(pat).len();
+    fn trim_end_matches_in_place(&mut self, mut pat: impl Pattern) -> &str {
+        let trimmed_str_length = deconstruct_pattern!(str::trim_end_matches, self, pat).len();
 
         unsafe {
             self.as_mut_vec().set_len(trimmed_str_length);


### PR DESCRIPTION
This makes `trim_start_matches_in_place` and `trim_end_matches_in_place` able to take `&str`, `char` or `FnMut(char) -> bool`, instead of just `char`, by collecting into a common type then dispatching again. This avoids having to name the unstable `Pattern` type while providing a useful amount of freedom.

This is a breaking change.